### PR TITLE
Fix layout so only content scrolls

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,22 +27,24 @@
     </nav>
   </header>
 
-  <!-- FEED gets populated from README -->
-  <main class="container" id="feed">
-    <noscript>
-      <article class="card">
-        <h2 class="post-title"><span class="jpn">オフライン</span> JavaScript Disabled</h2>
-        <p class="meta">Cannot fetch README without JS.</p>
-      </article>
-    </noscript>
-  </main>
+  <div class="content">
+    <!-- FEED gets populated from README -->
+    <main class="container" id="feed">
+      <noscript>
+        <article class="card">
+          <h2 class="post-title"><span class="jpn">オフライン</span> JavaScript Disabled</h2>
+          <p class="meta">Cannot fetch README without JS.</p>
+        </article>
+      </noscript>
+    </main>
 
-  <section class="about container" id="about">
-    <h3 class="section-title">ABOUT // OPERATOR</h3>
-    <p>
-      Static retro-future blog with neon glows, scanlines, and rainy parallax. The feed below is built on-the-fly from a Markdown README.
-    </p>
-  </section>
+    <section class="about container" id="about">
+      <h3 class="section-title">ABOUT // OPERATOR</h3>
+      <p>
+        Static retro-future blog with neon glows, scanlines, and rainy parallax. The feed below is built on-the-fly from a Markdown README.
+      </p>
+    </section>
+  </div>
 
   <footer class="site-footer">
     <p>© 2025 BUDOSTACK // Off-World Editions</p>
@@ -161,6 +163,17 @@
       const y = (e.clientY / window.innerHeight - 0.5) * 10;
       if (rain) rain.style.transform = `translate(${x}px, ${y}px)`;
       if (fog)  fog.style.transform  = `translate(${-x}px, ${-y}px)`;
+    });
+
+    // Smooth scrolling for internal links
+    document.querySelectorAll('a[href^="#"]').forEach(link => {
+      link.addEventListener('click', (e) => {
+        const target = document.getElementById(link.getAttribute('href').slice(1));
+        if (target) {
+          e.preventDefault();
+          target.scrollIntoView({ behavior: 'smooth' });
+        }
+      });
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -22,7 +22,10 @@ body{
               var(--bg);
   font-family: "Share Tech Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   line-height:1.6;
-  overflow-x:hidden;
+  display:flex;
+  flex-direction:column;
+  min-height:100vh;
+  overflow:hidden;
 }
 
 /* Subtle grid */
@@ -73,6 +76,13 @@ body::before{
 .site-header{
   padding:32px 18px 10px;
   text-align:center;
+  flex-shrink:0;
+}
+
+.site-footer{
+  text-align:center;
+  padding:20px 18px;
+  flex-shrink:0;
 }
 .logo{
   font-family:"Orbitron", system-ui, sans-serif;
@@ -139,6 +149,10 @@ body::before{
 
 /* Layout */
 .container{ width:min(960px, 92%); margin: 0 auto; }
+.content{
+  flex:1 1 auto;
+  overflow-y:auto;
+}
 
 /* Cards (posts) */
 .card{


### PR DESCRIPTION
## Summary
- Keep page header and footer fixed while scrolling by restructuring layout and hiding body overflow.
- Add scrollable content region and smooth scrolling for internal anchors.
- Style footer and header to avoid shrinking and ensure background remains static.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a374c3af408327a42036a0e6eb7af9