### PR TITLE
Add load-more pagination to commit feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       <noscript>
         <article class="card">
           <h2 class="post-title"><span class="jpn">オフライン</span> JavaScript Disabled</h2>
-          <p class="meta">Cannot fetch README without JS.</p>
+          <p class="meta">Enable JavaScript to view the live commit feed.</p>
         </article>
       </noscript>
     </main>
@@ -64,95 +64,379 @@
     <p>© 2025 BUDOSTACK // Off-World Editions</p>
   </footer>
 
-  <!-- Optional Markdown renderer if you later want rich excerpts -->
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-
   <script>
     // ========= CONFIG =========
-    const README_URL = 'https://raw.githubusercontent.com/sensei-zenabi/BUDOSTACK/main/users/ville/readme.md';
-    const GITHUB_README_PAGE = 'https://github.com/sensei-zenabi/BUDOSTACK/blob/main/users/ville/readme.md';
+    const OWNER = 'sensei-zenabi';
+    const REPO = 'BUDOSTACK';
+    const BRANCH = 'main';
+    const COMMITS_PER_PAGE = 10;
 
-    // Optional tiny cache (30 min)
-    const CACHE_KEY = 'ext_readme_cache_v1:' + README_URL;
-    const CACHE_TTL_MS = 30 * 60 * 1000;
+    const COMMITS_PAGE_URL = `https://github.com/${OWNER}/${REPO}/commits/${BRANCH}`;
+    const COMMITS_API_BASE_URL = `https://api.github.com/repos/${OWNER}/${REPO}/commits?sha=${BRANCH}`;
+
+    const CACHE_KEY = `commit_log_cache_v2:${OWNER}/${REPO}/${BRANCH}`;
+    const CACHE_TTL_MS = 15 * 60 * 1000;
+    const API_HEADERS = { 'Accept': 'application/vnd.github+json' };
 
     const feedEl = document.getElementById('feed');
 
-    function githubAnchorId(headingText) {
-      return headingText
-        .trim()
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, '')
-        .replace(/\s+/g, '-');
+    const state = {
+      commits: [],
+      page: 0,
+      hasMore: true,
+      isLoading: false,
+      lastError: null,
+    };
+
+    const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    function escapeHtml(value = '') {
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
     }
 
-    function parseDiary(md) {
-      const regex = /###\s+(.+?)\s+###\s*\n([\s\S]*?)(?=\n###\s|$)/g;
-      const entries = [];
-      let m;
+    function formatCommitDate(isoString) {
+      if (!isoString) return 'Unknown';
+      const date = new Date(isoString);
+      if (Number.isNaN(date.getTime())) return isoString;
 
-      while ((m = regex.exec(md)) !== null) {
-        const heading = m[1].trim();
-        const body    = (m[2] || '').trim();   // keep entire body
-        entries.push({ heading, body });
+      const dayName = DAY_NAMES[date.getDay()];
+      const monthName = MONTH_NAMES[date.getMonth()];
+      const day = String(date.getDate()).padStart(2, '0');
+      const hours = String(date.getHours()).padStart(2, '0');
+      const minutes = String(date.getMinutes()).padStart(2, '0');
+      const seconds = String(date.getSeconds()).padStart(2, '0');
+      const year = date.getFullYear();
+
+      const offsetMinutes = -date.getTimezoneOffset();
+      const offsetSign = offsetMinutes >= 0 ? '+' : '-';
+      const offsetTotal = Math.abs(offsetMinutes);
+      const offsetHours = String(Math.floor(offsetTotal / 60)).padStart(2, '0');
+      const offsetMins = String(offsetTotal % 60).padStart(2, '0');
+
+      return `${dayName} ${monthName} ${day} ${hours}:${minutes}:${seconds} ${year} ${offsetSign}${offsetHours}${offsetMins}`;
+    }
+
+    function formatGitLogBlock(commit) {
+      const parts = [];
+      parts.push(`commit ${commit.sha}`);
+
+      const authorBits = [];
+      if (commit.authorName) authorBits.push(commit.authorName);
+      if (commit.authorEmail) authorBits.push(`<${commit.authorEmail}>`);
+      parts.push(`Author: ${authorBits.join(' ') || 'Unknown'}`);
+      parts.push(`Date:   ${formatCommitDate(commit.dateIso)}`);
+      parts.push('');
+
+      const message = (commit.message || '(no commit message)').trimEnd();
+      const messageLines = message.split(/\r?\n/);
+      messageLines.forEach(line => {
+        parts.push(`    ${line}`);
+      });
+
+      if (commit.files && commit.files.length) {
+        parts.push('');
+        commit.files.forEach(file => parts.push(file));
       }
-      return entries;
+
+      return parts.join('\n');
     }
 
-    function renderEntries(entries) {
-      feedEl.innerHTML = '';
-      entries.forEach((e, idx) => {
-        const anchor = githubAnchorId(e.heading);
-        const link   = `${GITHUB_README_PAGE}#${anchor}`;
-        const num    = entries.length - idx;
+    function createSanitizedCommit(detail) {
+      const commit = detail.commit || {};
+      const author = commit.author || commit.committer || {};
+      const files = Array.isArray(detail.files) ? detail.files.map(f => f.filename) : [];
 
-        const article = document.createElement('article');
-        article.className = 'card';
-        article.innerHTML = `
+      return {
+        sha: detail.sha,
+        shortSha: detail.sha.slice(0, 7),
+        authorName: author.name || 'Unknown',
+        authorEmail: author.email || '',
+        dateIso: author.date || commit.author?.date || commit.committer?.date || '',
+        message: commit.message || '',
+        files,
+        htmlUrl: detail.html_url
+      };
+    }
+
+    function createCommitCard(commit) {
+      const article = document.createElement('article');
+      article.className = 'card';
+
+      const fileCount = commit.files.length;
+      const infoText = fileCount
+        ? `${fileCount} ${fileCount === 1 ? 'file' : 'files'} touched`
+        : 'No tracked files changed';
+
+      article.innerHTML = `
+        <div class="commit-title">
           <h2 class="post-title">
-            <a href="${link}" target="_blank" rel="noopener">
-              #${num} - ${e.heading}
+            <a href="${commit.htmlUrl}" target="_blank" rel="noopener">
+              commit ${escapeHtml(commit.shortSha)}
             </a>
           </h2>
-          <p class="meta">Type: Log Entry · Clearance: Public</p>
-          <div class="post-body">
-            ${marked.parse(e.body)}           <!-- full post -->
-          </div>
-          <a class="chip" href="${link}" target="_blank" rel="noopener">
-            OPEN FILE
-          </a>
-        `;
-        feedEl.appendChild(article);
-      });
+          <span>${escapeHtml(infoText)}</span>
+        </div>
+        <p class="meta">
+          Source: <a href="${COMMITS_PAGE_URL}" target="_blank" rel="noopener">${escapeHtml(`${OWNER}/${REPO}@${BRANCH}`)}</a>
+        </p>
+      `;
+
+      const pre = document.createElement('pre');
+      pre.className = 'git-log';
+      pre.textContent = formatGitLogBlock(commit);
+      article.appendChild(pre);
+
+      const actions = document.createElement('div');
+      actions.className = 'commit-actions';
+      actions.innerHTML = `
+        <a class="chip" href="${commit.htmlUrl}" target="_blank" rel="noopener">
+          VIEW COMMIT
+        </a>
+      `;
+      article.appendChild(actions);
+
+      return article;
     }
 
-    async function loadReadme() {
-      try {
-        const cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
-        if (cached && (Date.now() - cached.when) < CACHE_TTL_MS) {
-          renderEntries(parseDiary(cached.data));
-          return;
-        }
-      } catch (_) {}
+    function createLoadMoreCard() {
+      const card = document.createElement('article');
+      card.className = 'card load-more-card';
 
-      try {
-        const res = await fetch(README_URL, { mode: 'cors' });
-        if (!res.ok) throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
-        const md = await res.text();
-        renderEntries(parseDiary(md));
-        localStorage.setItem(CACHE_KEY, JSON.stringify({ when: Date.now(), data: md }));
-      } catch (err) {
-        console.error(err);
-        feedEl.innerHTML = `
-          <article class="card">
-            <h2 class="post-title">Couldn’t load README</h2>
-            <p class="meta">Check the README URL and CORS.</p>
-            <p>${String(err)}</p>
-          </article>`;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'neon-btn load-more-btn';
+      const count = state.commits.length;
+      const canAttemptLoad = state.hasMore || count === 0;
+      const buttonLabel = state.isLoading
+        ? 'Loading…'
+        : canAttemptLoad
+          ? (count ? 'LOAD MORE COMMITS' : 'LOAD COMMITS')
+          : 'ALL COMMITS LOADED';
+      button.textContent = buttonLabel;
+      button.disabled = state.isLoading || (!canAttemptLoad);
+      button.addEventListener('click', () => loadMoreCommits());
+
+      const status = document.createElement('p');
+      status.className = 'meta status-line';
+      const countLabel = `${count} ${count === 1 ? 'commit' : 'commits'}`;
+      status.textContent = count ? `Showing ${countLabel}.` : 'No commits cached yet.';
+
+      if (state.lastError) {
+        const error = document.createElement('p');
+        error.className = 'status-line error';
+        error.textContent = `Last attempt failed: ${state.lastError}`;
+        card.append(button, status, error);
+      } else {
+        card.append(button, status);
+      }
+
+      return card;
+    }
+
+    function renderCommits() {
+      feedEl.innerHTML = '';
+
+      if (!state.commits.length) {
+        const empty = document.createElement('article');
+        empty.className = 'card';
+        empty.innerHTML = `
+          <h2 class="post-title">No commits found</h2>
+          <p class="meta">We couldn’t find any commits yet. Try loading again shortly.</p>
+        `;
+        feedEl.appendChild(empty);
+      } else {
+        const fragment = document.createDocumentFragment();
+        state.commits.forEach(commit => fragment.appendChild(createCommitCard(commit)));
+        feedEl.appendChild(fragment);
+      }
+
+      const loadMoreCard = createLoadMoreCard();
+      feedEl.appendChild(loadMoreCard);
+    }
+
+    function renderLoading() {
+      feedEl.innerHTML = `
+        <article class="card">
+          <h2 class="post-title">Loading commits…</h2>
+          <p class="meta">Contacting GitHub for the latest activity.</p>
+        </article>`;
+    }
+
+    function renderError(error) {
+      feedEl.innerHTML = `
+        <article class="card">
+          <h2 class="post-title">Couldn’t load commits</h2>
+          <p class="meta">Check the GitHub API status or try again later.</p>
+          <p>${escapeHtml(String(error))}</p>
+          <div class="commit-actions">
+            <button type="button" class="neon-btn load-more-btn retry-btn">RETRY</button>
+            <a class="chip" href="${COMMITS_PAGE_URL}" target="_blank" rel="noopener">VIEW HISTORY</a>
+          </div>
+        </article>`;
+
+      const retryButton = feedEl.querySelector('.retry-btn');
+      if (retryButton) {
+        retryButton.addEventListener('click', () => loadMoreCommits({ replace: true }));
       }
     }
 
-    loadReadme();
+    function saveCache() {
+      try {
+        localStorage.setItem(CACHE_KEY, JSON.stringify({
+          when: Date.now(),
+          commits: state.commits,
+          page: state.page,
+          hasMore: state.hasMore,
+        }));
+      } catch (err) {
+        console.warn('Failed to store commit cache', err);
+      }
+    }
+
+    function restoreCache() {
+      try {
+        const cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+        if (!cached || !Array.isArray(cached.commits)) {
+          return false;
+        }
+
+        if (typeof cached.when === 'number' && (Date.now() - cached.when) > CACHE_TTL_MS) {
+          return false;
+        }
+
+        state.commits = cached.commits;
+        state.page = cached.page || (state.commits.length ? 1 : 0);
+        state.hasMore = typeof cached.hasMore === 'boolean' ? cached.hasMore : true;
+        state.lastError = null;
+        renderCommits();
+        return true;
+      } catch (err) {
+        console.warn('Failed to read commit cache', err);
+        return false;
+      }
+    }
+
+    async function fetchCommitsPage(page) {
+      const url = `${COMMITS_API_BASE_URL}&per_page=${COMMITS_PER_PAGE}&page=${page}`;
+      const listResponse = await fetch(url, { headers: API_HEADERS });
+      if (!listResponse.ok) {
+        throw new Error(`List request failed: ${listResponse.status} ${listResponse.statusText}`);
+      }
+
+      const summaries = await listResponse.json();
+      const linkHeader = listResponse.headers.get('link') || '';
+      const hasNext = /rel="next"/.test(linkHeader);
+
+      const commitDetails = await Promise.all(
+        summaries.map(summary =>
+          fetch(summary.url, { headers: API_HEADERS })
+            .then(res => {
+              if (!res.ok) {
+                throw new Error(`Detail request failed for ${summary.sha}: ${res.status} ${res.statusText}`);
+              }
+              return res.json();
+            })
+        )
+      );
+
+      return {
+        commits: commitDetails.map(createSanitizedCommit),
+        hasNext,
+      };
+    }
+
+    async function loadMoreCommits({ replace = false } = {}) {
+      if (state.isLoading) {
+        return;
+      }
+
+      const targetPage = replace ? 1 : state.page + 1;
+      if (!replace && !state.hasMore && state.commits.length) {
+        return;
+      }
+
+      state.lastError = null;
+      state.isLoading = true;
+
+      if (state.commits.length) {
+        renderCommits();
+      } else {
+        renderLoading();
+      }
+
+      const previousCommits = state.commits.slice();
+      const previousPage = state.page;
+
+      try {
+        const { commits: newCommits, hasNext } = await fetchCommitsPage(targetPage);
+        state.lastError = null;
+
+        if (replace) {
+          const seen = new Set();
+          const merged = [];
+          newCommits.forEach(commit => {
+            if (!seen.has(commit.sha)) {
+              merged.push(commit);
+              seen.add(commit.sha);
+            }
+          });
+          previousCommits.forEach(commit => {
+            if (!seen.has(commit.sha)) {
+              merged.push(commit);
+              seen.add(commit.sha);
+            }
+          });
+          state.commits = merged;
+          const nextPageValue = newCommits.length ? targetPage : 0;
+          state.page = Math.max(previousPage, nextPageValue);
+        } else if (newCommits.length) {
+          const merged = previousCommits.slice();
+          const seen = new Set(merged.map(commit => commit.sha));
+          newCommits.forEach(commit => {
+            if (!seen.has(commit.sha)) {
+              merged.push(commit);
+              seen.add(commit.sha);
+            }
+          });
+          state.commits = merged;
+          state.page = targetPage;
+        } else {
+          state.commits = previousCommits;
+          state.page = previousPage;
+        }
+
+        state.hasMore = hasNext;
+        if (!newCommits.length && !hasNext) {
+          state.hasMore = false;
+        }
+
+        saveCache();
+      } catch (err) {
+        console.error(err);
+        state.lastError = err instanceof Error ? err.message : String(err);
+        if (!state.commits.length) {
+          renderError(state.lastError);
+        }
+      } finally {
+        state.isLoading = false;
+        if (state.commits.length || (!state.commits.length && !state.lastError)) {
+          renderCommits();
+        }
+      }
+    }
+
+    const hadCache = restoreCache();
+    if (!hadCache) {
+      renderLoading();
+    }
+
+    loadMoreCommits({ replace: true });
 
     // Toggle between feed and about sections
     const aboutSection = document.getElementById('about');

--- a/style.css
+++ b/style.css
@@ -196,4 +196,109 @@ body::before{
   font-family:"Orbitron", system-ui, sans-serif;
   letter-spacing:.04em;
 }
-.po
+
+.post-title a{
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.post-title a:hover{
+  color: var(--cyan);
+}
+
+.meta{
+  margin: 0 0 16px;
+  color: var(--dim);
+  font-size: 13px;
+}
+
+.meta a{
+  color: var(--cyan);
+  text-decoration: none;
+}
+
+.meta a:hover{
+  text-decoration: underline;
+}
+
+.commit-title{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  flex-wrap:wrap;
+}
+
+.commit-title span{
+  font-size:12px;
+  color:var(--dim);
+  text-transform:uppercase;
+  letter-spacing:.1em;
+}
+
+.git-log{
+  margin:0;
+  padding:16px;
+  background:rgba(4,6,13,.65);
+  border:1px solid rgba(0,229,255,.2);
+  border-radius:12px;
+  font-size:14px;
+  line-height:1.6;
+  white-space:pre-wrap;
+  word-break:break-word;
+  box-shadow: inset 0 0 22px rgba(0,229,255,.08);
+}
+
+.commit-actions{
+  margin-top:16px;
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+}
+
+.chip{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 14px;
+  border-radius:999px;
+  border:1px solid rgba(0,229,255,.35);
+  background: rgba(10,15,31,.55);
+  color:var(--fg);
+  text-decoration:none;
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:.12em;
+  transition: border-color .2s ease, box-shadow .2s ease, transform .15s ease;
+}
+
+.chip:hover{
+  border-color:var(--cyan);
+  box-shadow:0 0 14px rgba(0,229,255,.24);
+  transform:translateY(-1px);
+}
+
+.load-more-card{
+  text-align:center;
+}
+
+.load-more-btn{
+  font-family:"Share Tech Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size:14px;
+  cursor:pointer;
+  min-width:220px;
+}
+
+.load-more-btn:disabled{
+  cursor:not-allowed;
+  opacity:.6;
+  box-shadow:none;
+}
+
+.status-line{
+  margin-top:10px;
+}
+
+.status-line.error{
+  color:#ff6b9a;
+}


### PR DESCRIPTION
## Summary
- add stateful pagination for the commit feed and reuse cached entries when refreshing
- append a load more card with retry support so visitors can page through the full history
- style the load more controls to match the neon theme and surface error messaging

## Testing
- not run (per instructions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bed772fc8327881be5dd8e039af0)