### PR TITLE
Restyle site with retro advertisement aesthetic

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
   <!-- Fonts + Styles -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bungee+Shade&family=Space+Grotesk:wght@400;600&family=VT323&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
   <meta name="theme-color" content="#0a0f1f">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" crossorigin="anonymous"></script>
@@ -19,39 +19,43 @@
   <div class="bg fog"></div>
   <div class="scanlines"></div>
 
-  <header class="site-header">
-    <div class="logo glitch" data-text="BUDOSTACK">BUDOSTACK</div>
-    <p class="tag"> - Welcome Back to 1980s -</p>
-    <nav class="nav">
-      <a class="neon-btn" href="https://github.com/sensei-zenabi/BUDOSTACK/tags">RELEASES</a>
-      <a class="neon-btn" href="#about" id="about-btn">NEWS</a>
-      <a class="neon-btn" href="#feed" id="feed-btn">COMMITS</a>
-    </nav>
-  </header>
+  <div class="poster-shell">
+    <header class="site-header">
+      <div class="badge">1985 EDITION</div>
+      <div class="logo glitch" data-text="BUDOSTACK">BUDOSTACK</div>
+      <p class="tag">Personal computing power with neon attitude.</p>
+      <div class="subtag">Engineered for visionaries, rebels, and late-night coders.</div>
+      <nav class="nav">
+        <a class="neon-btn" href="https://github.com/sensei-zenabi/BUDOSTACK/tags">RELEASES</a>
+        <a class="neon-btn" href="#about" id="about-btn">NEWS</a>
+        <a class="neon-btn" href="#feed" id="feed-btn">COMMITS</a>
+      </nav>
+    </header>
 
-  <div class="content">
-    <!-- FEED gets populated from README -->
-    <main class="container" id="feed">
-      <noscript>
-        <article class="card">
-          <h2 class="post-title"><span class="jpn">オフライン</span> JavaScript Disabled</h2>
-          <p class="meta">Enable JavaScript to view the live commit feed.</p>
-        </article>
-      </noscript>
-    </main>
+    <div class="content">
+      <!-- FEED gets populated from README -->
+      <main class="container" id="feed">
+        <noscript>
+          <article class="card">
+            <h2 class="post-title"><span class="jpn">オフライン</span> JavaScript Disabled</h2>
+            <p class="meta">Enable JavaScript to view the live commit feed.</p>
+          </article>
+        </noscript>
+      </main>
 
-    <section class="about container hidden" id="about">
-      <h2 class="section-title">BUDOSTACK NEWS</h3>
-      <div id="news-content" class="news-content">
-        <p>Loading latest news...</p>
-      </div>
-      <img src="images/about.png" alt="About" class="about-photo">
-    </section>
+      <section class="about container hidden" id="about">
+        <h2 class="section-title">BUDOSTACK NEWS</h2>
+        <div id="news-content" class="news-content">
+          <p>Loading latest news...</p>
+        </div>
+        <img src="images/about.png" alt="About" class="about-photo">
+      </section>
+    </div>
+
+    <footer class="site-footer">
+      <p>© 2025 BUDOSTACK // Ville Suoranta</p>
+    </footer>
   </div>
-
-  <footer class="site-footer">
-    <p>© 2025 BUDOSTACK // Ville Suoranta</p>
-  </footer>
 
   <script>
     // ========= CONFIG =========

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
   <!-- Fonts + Styles -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Bungee+Shade&family=Space+Grotesk:wght@400;600&family=VT323&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Syncopate:wght@400;700&family=Space+Grotesk:wght@400;600&family=VT323&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
   <meta name="theme-color" content="#0a0f1f">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" crossorigin="anonymous"></script>
@@ -23,8 +23,8 @@
     <header class="site-header">
       <div class="badge">1985 EDITION</div>
       <div class="logo glitch" data-text="BUDOSTACK">BUDOSTACK</div>
-      <p class="tag">Personal computing power with neon attitude.</p>
-      <div class="subtag">Engineered for visionaries, rebels, and late-night coders.</div>
+      <p class="tag">Personal computing by design.</p>
+      <div class="subtag">Precision graphics, midnight coding, and desk-ready charisma.</div>
       <nav class="nav">
         <a class="neon-btn" href="https://github.com/sensei-zenabi/BUDOSTACK/tags">RELEASES</a>
         <a class="neon-btn" href="#about" id="about-btn">NEWS</a>

--- a/style.css
+++ b/style.css
@@ -1,18 +1,17 @@
 /* ========== Variables & Base ========== */
 :root{
-  --bg:#0d0a17;
-  --bg2:#1f143a;
-  --cream:#faf0d7;
-  --fg:#fef7e4;
-  --dim:#d0c6b5;
-  --cyan:#6ff3ff;
-  --mag:#ff4dba;
-  --amber:#ffd166;
-  --ink:#17121f;
-  --card:#110b20e6;
-  --shadow:#ff4dba33;
+  --bg:#f7f2e7;
+  --bg2:#f0e7d6;
+  --fg:#0c0b15;
+  --dim:#413f4c;
+  --cyan:#00a8e8;
+  --mag:#e60073;
+  --amber:#f5a623;
+  --ink:#0c0b15;
+  --card:#fffffffa;
+  --shadow:#001b4433;
   --radius:14px;
-  --font-logo:'Bungee Shade', 'VT323', system-ui, sans-serif;
+  --font-logo:'Syncopate', 'Space Grotesk', system-ui, sans-serif;
   --font-body:'Space Grotesk', 'IBM Plex Sans', system-ui, sans-serif;
   --font-mono:'VT323', 'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
 }
@@ -23,10 +22,10 @@ body{
   margin:0;
   color:var(--fg);
   background:
-    radial-gradient(circle at 18% 20%, rgba(255, 209, 102,.18), transparent 32%),
-    radial-gradient(circle at 82% 10%, rgba(255, 77, 186,.18), transparent 35%),
-    radial-gradient(circle at 50% 70%, rgba(111, 243, 255,.14), transparent 42%),
-    linear-gradient(135deg, #0b0816 0%, #1c1130 40%, #0b0816 100%);
+    linear-gradient(180deg, rgba(0,168,232,.14) 0 120px, transparent 120px),
+    linear-gradient(90deg, rgba(245,166,35,.08) 0 12%, transparent 12% 88%, rgba(230,0,115,.08) 88% 100%),
+    repeating-linear-gradient(0deg, rgba(12,11,21,.04) 0 1px, transparent 1px 14px),
+    var(--bg);
   font-family: var(--font-body);
   line-height:1.6;
   display:flex;
@@ -44,82 +43,54 @@ body::before{
   content:"";
   position:fixed; inset:0;
   background:
-    linear-gradient(90deg, rgba(255,209,102,.06) 1px, transparent 1px) 0 0/48px 100%,
-    linear-gradient(0deg, rgba(111,243,255,.05) 1px, transparent 1px) 0 0/100% 48px,
-    radial-gradient(circle at 50% 50%, rgba(255,255,255,.06), transparent 42%);
+    linear-gradient(120deg, rgba(230,0,115,.05) 0 8%, transparent 8% 92%, rgba(0,168,232,.05) 92% 100%),
+    linear-gradient(0deg, rgba(12,11,21,.05) 1px, transparent 1px) 0 0/100% 26px,
+    linear-gradient(90deg, rgba(12,11,21,.04) 1px, transparent 1px) 0 0/26px 100%;
   pointer-events:none;
-  mix-blend-mode:screen;
+  mix-blend-mode:multiply;
   opacity:.5;
 }
 
 /* Rain & fog layers */
-.bg{position:fixed; inset:0; pointer-events:none; z-index:-1;}
-.rain{
-  background:
-    repeating-linear-gradient(120deg, rgba(255,255,255,.0) 0 4px, rgba(255,255,255,.08) 4px 5px, rgba(255,255,255,0) 5px 120px);
-  animation: rain 6s linear infinite;
-  opacity:.12;
-}
-@keyframes rain{
-  to{background-position: -800px 1200px;}
-}
-.fog{
-  background:
-    radial-gradient(800px 500px at 20% 30%, rgba(255,255,255,.06), transparent 60%),
-    radial-gradient(900px 600px at 80% 70%, rgba(255,255,255,.05), transparent 60%);
-  filter: blur(6px);
-  opacity:.32;
-  animation: drift 40s linear infinite alternate;
-}
-@keyframes drift{
-  to{transform: translate3d(10px,-10px,0);}
-}
+.bg{display:none;}
 
 /* CRT scanlines */
-.scanlines{
-  position:fixed; inset:0; pointer-events:none;
-  background: repeating-linear-gradient(to bottom, rgba(255,255,255,.06) 0 1px, transparent 1px 3px);
-  mix-blend-mode: overlay;
-  opacity:.25;
-  z-index: 999;
-}
+.scanlines{display:none;}
 
 .poster-shell{
   width:min(1040px, 96%);
-  margin:36px auto 26px;
-  background: linear-gradient(180deg, rgba(17,12,32,.9), rgba(17,12,32,.72));
-  border: 2px solid rgba(255, 209, 102, .5);
+  margin:48px auto 32px;
+  background: var(--card);
+  border: 1px solid rgba(12,11,21,.08);
   box-shadow:
-    0 14px 40px rgba(0,0,0,.55),
-    0 0 0 10px rgba(17,12,32,.85),
-    0 0 0 14px rgba(111,243,255,.16),
-    0 0 68px rgba(255,77,186,.25);
-  border-radius: 20px;
+    0 20px 42px rgba(0,0,0,.12),
+    0 0 0 14px rgba(12,11,21,.04);
+  border-radius: 18px;
   position:relative;
   overflow:hidden;
 }
 
 .poster-shell::before{
   content:"";
-  position:absolute; inset:12px;
-  border:1px dashed rgba(255,209,102,.35);
-  border-radius:14px;
+  position:absolute; inset:18px 16px 10px 16px;
+  border:1px solid rgba(12,11,21,.08);
+  border-radius:12px;
   pointer-events:none;
+  box-shadow: inset 0 8px 0 rgba(0,168,232,.08);
 }
 
 .poster-shell::after{
-  content:"NEW POWER";
+  content:"DESKTOP SERIES";
   position:absolute;
-  top:16px; right:-32px;
-  transform: rotate(8deg);
-  background: linear-gradient(135deg, #ffd166, #ff4dba);
-  color:var(--ink);
-  font-family: var(--font-mono);
-  padding:6px 38px;
-  letter-spacing:.18em;
-  box-shadow: 0 12px 18px rgba(0,0,0,.35);
-  text-shadow:none;
-  clip-path: polygon(0 0, 92% 0, 100% 50%, 92% 100%, 0 100%);
+  top:18px; right:-18px;
+  transform: skew(-8deg);
+  background: linear-gradient(90deg, #0c0b15, #1f2743);
+  color:var(--bg);
+  font-family: var(--font-logo);
+  padding:8px 34px;
+  letter-spacing:.16em;
+  box-shadow: 0 10px 22px rgba(0,0,0,.2);
+  text-shadow: 0 0 4px rgba(245,166,35,.65);
 }
 
 /* Header */
@@ -146,9 +117,9 @@ body::before{
   text-transform: uppercase;
   color:var(--fg);
   text-shadow:
-    0 0 12px rgba(111,243,255,.9),
-    0 0 28px rgba(255,77,186,.7),
-    0 4px 0 rgba(23,18,31,.8);
+    0 6px 0 rgba(12,11,21,.12),
+    0 0 18px rgba(0,168,232,.35),
+    0 0 32px rgba(230,0,115,.25);
 }
 .logo.flicker{ animation: flick 0.2s linear 1; }
 @keyframes flick{
@@ -186,7 +157,7 @@ body::before{
 
 .tag{
   margin:10px 0 6px;
-  color:var(--amber);
+  color:var(--cyan);
   font-size:16px;
   text-transform:uppercase;
   letter-spacing:.18em;
@@ -200,13 +171,13 @@ body::before{
 
 .badge{
   display:inline-block;
-  background: linear-gradient(90deg, #ff4dba, #ffd166);
-  color:var(--ink);
+  background: linear-gradient(90deg, #0c0b15, #1f2743);
+  color:var(--bg);
   padding:8px 18px;
   border-radius:999px;
-  font-family: var(--font-mono);
+  font-family: var(--font-logo);
   letter-spacing:.16em;
-  box-shadow: 0 8px 16px rgba(0,0,0,.35);
+  box-shadow: 0 8px 16px rgba(0,0,0,.18);
   text-transform:uppercase;
 }
 
@@ -220,12 +191,11 @@ body::before{
 
 .news-content {
   background: var(--card);
-  border: 1px solid rgba(255, 209, 102, 0.35);
+  border: 1px solid rgba(12,11,21, 0.08);
   border-radius: var(--radius);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45), 0 0 22px rgba(255,77,186,.16);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
   padding: 18px;
   margin-bottom: 18px;
-  backdrop-filter: blur(4px);
 }
 
 .news-content h1,
@@ -235,12 +205,12 @@ body::before{
 .news-content h5,
 .news-content h6 {
   margin: 0 0 8px;
-  color: var(--cyan);
+  color: var(--mag);
 }
 
 .news-content p,
 .news-content li {
-  color: var(--fg);
+  color: var(--ink);
   line-height: 1.7;
   font-family: var(--font-body);
 }
@@ -274,32 +244,34 @@ body::before{
 }
 
 .section-title{
-  font-family: var(--font-mono);
-  letter-spacing:.18em;
-  color:var(--amber);
+  font-family: var(--font-logo);
+  letter-spacing:.12em;
+  color:var(--mag);
   margin-bottom:12px;
   text-transform:uppercase;
 }
 
 .about-photo {
-  border:2px solid rgba(255,209,102,.4);
-  box-shadow:0 18px 32px rgba(0,0,0,.4);
-  background: radial-gradient(circle at 20% 20%, rgba(255,77,186,.3), transparent 40%);
+  border:2px solid rgba(12,11,21,.08);
+  box-shadow:0 12px 26px rgba(0,0,0,.18);
+  background: radial-gradient(circle at 22% 22%, rgba(245,166,35,.16), transparent 40%);
 }
 
 /* Nav */
 .nav{ display:flex; gap:12px; justify-content:center; flex-wrap:wrap; margin-bottom:18px; }
 .neon-btn{
-  padding:12px 18px; border-radius:10px; text-decoration:none; color:var(--ink);
-  border:2px solid rgba(23,18,31,.6);
-  box-shadow: 0 10px 0 rgba(23,18,31,.7), 0 8px 28px rgba(0,0,0,.4);
-  background: linear-gradient(135deg, #ffd166 0%, #ff4dba 50%, #6ff3ff 100%);
-  font-family: var(--font-mono);
+  padding:12px 18px; border-radius:10px; text-decoration:none; color:var(--fg);
+  border:2px solid rgba(12,11,21,.22);
+  box-shadow: 0 10px 0 rgba(12,11,21,.16), 0 12px 24px rgba(0,0,0,.12);
+  background:
+    linear-gradient(90deg, rgba(0,168,232,.18), rgba(0,168,232,.18)),
+    linear-gradient(135deg, #ffffff 0%, #f2ede1 50%, #ffffff 100%);
+  font-family: var(--font-logo);
   letter-spacing:.16em;
   text-transform:uppercase;
   transition: transform .12s ease, box-shadow .12s ease, filter .2s ease;
 }
-.neon-btn:hover{ transform: translateY(-3px); box-shadow: 0 13px 0 rgba(23,18,31,.7), 0 12px 32px rgba(0,0,0,.5); filter:saturate(1.15); }
+.neon-btn:hover{ transform: translateY(-3px); box-shadow: 0 13px 0 rgba(12,11,21,.18), 0 12px 30px rgba(0,0,0,.16); filter:saturate(1.08); }
 
 /* Layout */
 .container{ width:min(960px, 92%); margin: 0 auto; }
@@ -334,16 +306,18 @@ body::before{
   font-size:14px;
   text-transform:uppercase;
   letter-spacing:.16em;
-  background: linear-gradient(135deg, rgba(255,209,102,.95), rgba(111,243,255,.9));
-  color:var(--ink);
-  border:2px solid rgba(23,18,31,.8);
-  box-shadow:0 10px 0 rgba(23,18,31,.7), 0 12px 32px rgba(0,0,0,.45);
+  background:
+    repeating-linear-gradient(90deg, rgba(0,168,232,.2) 0 12px, transparent 12px 24px),
+    linear-gradient(135deg, #ffffff, #f0e7d6);
+  color:var(--fg);
+  border:2px solid rgba(12,11,21,.24);
+  box-shadow:0 10px 0 rgba(12,11,21,.14), 0 12px 26px rgba(0,0,0,.14);
 }
 
 .load-more-btn:disabled{
   cursor:not-allowed;
   opacity:.6;
-  box-shadow:0 6px 0 rgba(23,18,31,.6), inset 0 0 8px rgba(255,77,186,.2);
+  box-shadow:0 6px 0 rgba(12,11,21,.08), inset 0 0 8px rgba(0,168,232,.12);
   transform:none;
 }
 
@@ -366,20 +340,22 @@ body::before{
 
 /* Cards (posts) */
 .card{
-  background: linear-gradient(125deg, rgba(17,12,32,.9) 0%, rgba(17,12,32,.72) 50%, rgba(17,12,32,.92) 100%);
-  border:2px solid rgba(255,209,102,.4);
+  background:
+    linear-gradient(90deg, rgba(0,168,232,.14) 0 12px, transparent 12px 100%),
+    linear-gradient(135deg, #ffffff 0%, #f5f0e4 60%, #ffffff 100%);
+  border:2px solid rgba(12,11,21,.08);
   border-radius: 18px;
   padding: 22px 20px 18px;
   margin: 20px 0;
-  box-shadow: 0 16px 40px rgba(0,0,0,.45), 0 0 0 3px rgba(23,18,31,.7), 0 0 48px rgba(255,77,186,.16);
+  box-shadow: 0 16px 34px rgba(0,0,0,.14), 0 0 0 3px rgba(12,11,21,.04);
   position:relative;
   overflow:hidden;
 }
 .card::after{
   content:""; position:absolute; inset:0;
   background:
-    linear-gradient(135deg, rgba(255,209,102,.1), transparent 32%),
-    linear-gradient(315deg, rgba(111,243,255,.12), transparent 35%);
+    linear-gradient(135deg, rgba(245,166,35,.16), transparent 32%),
+    linear-gradient(315deg, rgba(0,168,232,.16), transparent 35%);
   z-index:-1;
   opacity:.6;
 }
@@ -389,17 +365,15 @@ body::before{
   font-family: var(--font-mono);
   letter-spacing:.14em;
   text-transform:uppercase;
-  color:var(--fg);
+  color:var(--ink);
 }
 
 .post-title a{
-  color: var(--fg);
+  color: var(--ink);
   text-decoration: none;
 }
 
-.post-title a:hover{
-  color: var(--cyan);
-}
+.post-title a:hover{ color: var(--mag); }
 
 .meta{
   margin: 0 0 16px;
@@ -435,14 +409,14 @@ body::before{
 .git-log{
   margin:0;
   padding:18px;
-  background:rgba(12,10,20,.82);
-  border:1px solid rgba(255,209,102,.28);
+  background:linear-gradient(180deg, rgba(0,168,232,.12), transparent 60%), #ffffff;
+  border:1px solid rgba(12,11,21,.1);
   border-radius:12px;
   font-size:15px;
   line-height:1.55;
   white-space:pre-wrap;
   word-break:break-word;
-  box-shadow: inset 0 0 22px rgba(255,77,186,.12);
+  box-shadow: inset 0 0 14px rgba(0,0,0,.04);
   font-family: var(--font-mono);
 }
 
@@ -459,9 +433,9 @@ body::before{
   gap:6px;
   padding:6px 14px;
   border-radius:999px;
-  border:1px solid rgba(255,209,102,.35);
-  background: rgba(15,12,24,.75);
-  color:var(--amber);
+  border:1px solid rgba(12,11,21,.12);
+  background: rgba(0,168,232,.08);
+  color:var(--ink);
   text-decoration:none;
   font-size:12px;
   text-transform:uppercase;
@@ -470,7 +444,7 @@ body::before{
 }
 
 .chip:hover{
-  border-color:var(--amber);
-  box-shadow:0 0 14px rgba(255,209,102,.28);
+  border-color:var(--mag);
+  box-shadow:0 0 14px rgba(230,0,115,.18);
   transform:translateY(-1px);
 }

--- a/style.css
+++ b/style.css
@@ -1,32 +1,40 @@
 /* ========== Variables & Base ========== */
 :root{
-  --bg:#070a16;
-  --bg2:#0a0f1f;
-  --fg:#cce7ff;
-  --dim:#8aa3bf;
-  --cyan:#00e5ff;
-  --mag:#ff00cc;
-  --amber:#ffe066;
-  --card:#0e1530cc;
-  --shadow:#00e5ff44;
+  --bg:#0d0a17;
+  --bg2:#1f143a;
+  --cream:#faf0d7;
+  --fg:#fef7e4;
+  --dim:#d0c6b5;
+  --cyan:#6ff3ff;
+  --mag:#ff4dba;
+  --amber:#ffd166;
+  --ink:#17121f;
+  --card:#110b20e6;
+  --shadow:#ff4dba33;
   --radius:14px;
+  --font-logo:'Bungee Shade', 'VT323', system-ui, sans-serif;
+  --font-body:'Space Grotesk', 'IBM Plex Sans', system-ui, sans-serif;
+  --font-mono:'VT323', 'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
 }
 
 *{box-sizing:border-box}
 html,body{height:100%}
-  body{
-    margin:0;
-    color:var(--fg);
-    background: radial-gradient(1200px 800px at 20% 10%, #0b1633 0%, #070a16 60%, #04060d 100%),
-                radial-gradient(900px 600px at 90% 80%, #1a0b24 0%, transparent 60%) ,
-                var(--bg);
-    font-family: "Share Tech Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-    line-height:1.6;
-    display:flex;
-    flex-direction:column;
-    min-height:100vh;
-    overflow:hidden;
-  }
+body{
+  margin:0;
+  color:var(--fg);
+  background:
+    radial-gradient(circle at 18% 20%, rgba(255, 209, 102,.18), transparent 32%),
+    radial-gradient(circle at 82% 10%, rgba(255, 77, 186,.18), transparent 35%),
+    radial-gradient(circle at 50% 70%, rgba(111, 243, 255,.14), transparent 42%),
+    linear-gradient(135deg, #0b0816 0%, #1c1130 40%, #0b0816 100%);
+  font-family: var(--font-body);
+  line-height:1.6;
+  display:flex;
+  flex-direction:column;
+  min-height:100vh;
+  overflow:hidden;
+  position:relative;
+}
 
 /* Utility classes */
 .hidden{display:none;}
@@ -36,11 +44,12 @@ body::before{
   content:"";
   position:fixed; inset:0;
   background:
-    linear-gradient(to right, rgba(0,229,255,.07) 1px, transparent 1px) 0 0/40px 100%,
-    linear-gradient(to bottom, rgba(255,0,204,.05) 1px, transparent 1px) 0 0/100% 40px;
+    linear-gradient(90deg, rgba(255,209,102,.06) 1px, transparent 1px) 0 0/48px 100%,
+    linear-gradient(0deg, rgba(111,243,255,.05) 1px, transparent 1px) 0 0/100% 48px,
+    radial-gradient(circle at 50% 50%, rgba(255,255,255,.06), transparent 42%);
   pointer-events:none;
   mix-blend-mode:screen;
-  opacity:.4;
+  opacity:.5;
 }
 
 /* Rain & fog layers */
@@ -49,7 +58,7 @@ body::before{
   background:
     repeating-linear-gradient(120deg, rgba(255,255,255,.0) 0 4px, rgba(255,255,255,.08) 4px 5px, rgba(255,255,255,0) 5px 120px);
   animation: rain 6s linear infinite;
-  opacity:.18;
+  opacity:.12;
 }
 @keyframes rain{
   to{background-position: -800px 1200px;}
@@ -59,7 +68,7 @@ body::before{
     radial-gradient(800px 500px at 20% 30%, rgba(255,255,255,.06), transparent 60%),
     radial-gradient(900px 600px at 80% 70%, rgba(255,255,255,.05), transparent 60%);
   filter: blur(6px);
-  opacity:.4;
+  opacity:.32;
   animation: drift 40s linear infinite alternate;
 }
 @keyframes drift{
@@ -75,28 +84,71 @@ body::before{
   z-index: 999;
 }
 
+.poster-shell{
+  width:min(1040px, 96%);
+  margin:36px auto 26px;
+  background: linear-gradient(180deg, rgba(17,12,32,.9), rgba(17,12,32,.72));
+  border: 2px solid rgba(255, 209, 102, .5);
+  box-shadow:
+    0 14px 40px rgba(0,0,0,.55),
+    0 0 0 10px rgba(17,12,32,.85),
+    0 0 0 14px rgba(111,243,255,.16),
+    0 0 68px rgba(255,77,186,.25);
+  border-radius: 20px;
+  position:relative;
+  overflow:hidden;
+}
+
+.poster-shell::before{
+  content:"";
+  position:absolute; inset:12px;
+  border:1px dashed rgba(255,209,102,.35);
+  border-radius:14px;
+  pointer-events:none;
+}
+
+.poster-shell::after{
+  content:"NEW POWER";
+  position:absolute;
+  top:16px; right:-32px;
+  transform: rotate(8deg);
+  background: linear-gradient(135deg, #ffd166, #ff4dba);
+  color:var(--ink);
+  font-family: var(--font-mono);
+  padding:6px 38px;
+  letter-spacing:.18em;
+  box-shadow: 0 12px 18px rgba(0,0,0,.35);
+  text-shadow:none;
+  clip-path: polygon(0 0, 92% 0, 100% 50%, 92% 100%, 0 100%);
+}
+
 /* Header */
 .site-header{
-  padding:32px 18px 10px;
+  padding:42px 28px 18px;
   text-align:center;
   flex-shrink:0;
+  position:relative;
 }
 
 .site-footer{
   text-align:center;
-  padding:20px 18px;
+  padding:22px 18px 28px;
   flex-shrink:0;
+  letter-spacing:.08em;
+  color:var(--dim);
+  font-size:13px;
+  text-transform:uppercase;
 }
 .logo{
-  font-family:"Orbitron", system-ui, sans-serif;
-  font-size: clamp(28px, 5vw, 56px);
-  letter-spacing: .08em;
+  font-family: var(--font-logo);
+  font-size: clamp(36px, 7vw, 84px);
+  letter-spacing: .12em;
   text-transform: uppercase;
   color:var(--fg);
   text-shadow:
-    0 0 6px var(--cyan),
-    0 0 18px var(--cyan),
-    0 0 36px var(--mag);
+    0 0 12px rgba(111,243,255,.9),
+    0 0 28px rgba(255,77,186,.7),
+    0 4px 0 rgba(23,18,31,.8);
 }
 .logo.flicker{ animation: flick 0.2s linear 1; }
 @keyframes flick{
@@ -133,9 +185,29 @@ body::before{
 }
 
 .tag{
-  margin:8px 0 16px;
+  margin:10px 0 6px;
+  color:var(--amber);
+  font-size:16px;
+  text-transform:uppercase;
+  letter-spacing:.18em;
+}
+
+.subtag{
   color:var(--dim);
-  font-size:14px;
+  font-size:15px;
+  margin-bottom:20px;
+}
+
+.badge{
+  display:inline-block;
+  background: linear-gradient(90deg, #ff4dba, #ffd166);
+  color:var(--ink);
+  padding:8px 18px;
+  border-radius:999px;
+  font-family: var(--font-mono);
+  letter-spacing:.16em;
+  box-shadow: 0 8px 16px rgba(0,0,0,.35);
+  text-transform:uppercase;
 }
 
 /* About */
@@ -148,9 +220,9 @@ body::before{
 
 .news-content {
   background: var(--card);
-  border: 1px solid rgba(0, 229, 255, 0.25);
+  border: 1px solid rgba(255, 209, 102, 0.35);
   border-radius: var(--radius);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45), 0 0 12px var(--shadow);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45), 0 0 22px rgba(255,77,186,.16);
   padding: 18px;
   margin-bottom: 18px;
   backdrop-filter: blur(4px);
@@ -170,6 +242,7 @@ body::before{
 .news-content li {
   color: var(--fg);
   line-height: 1.7;
+  font-family: var(--font-body);
 }
 
 .news-content a {
@@ -185,6 +258,7 @@ body::before{
   background: rgba(255, 255, 255, 0.06);
   padding: 2px 5px;
   border-radius: 6px;
+  font-family: var(--font-mono);
 }
 
 .news-content pre {
@@ -192,23 +266,40 @@ body::before{
   padding: 12px;
   border-radius: 10px;
   overflow-x: auto;
+  font-family: var(--font-mono);
 }
 
 .news-content .error {
   color: #ff9b9b;
 }
 
-/* Nav */
-.nav{ display:flex; gap:10px; justify-content:center; flex-wrap:wrap; margin-bottom:18px; }
-.neon-btn{
-  padding:10px 14px; border-radius:999px; text-decoration:none; color:var(--fg);
-  border:1px solid rgba(0,229,255,.4);
-  box-shadow: 0 0 10px var(--shadow), inset 0 0 8px rgba(255,0,204,.2);
-  background: linear-gradient(180deg, rgba(0,229,255,.12), rgba(255,0,204,.06));
-  backdrop-filter: blur(3px);
-  transition: transform .15s ease, box-shadow .2s ease, border-color .2s ease;
+.section-title{
+  font-family: var(--font-mono);
+  letter-spacing:.18em;
+  color:var(--amber);
+  margin-bottom:12px;
+  text-transform:uppercase;
 }
-.neon-btn:hover{ transform: translateY(-1px) scale(1.02); border-color: var(--cyan); box-shadow: 0 0 18px var(--shadow); }
+
+.about-photo {
+  border:2px solid rgba(255,209,102,.4);
+  box-shadow:0 18px 32px rgba(0,0,0,.4);
+  background: radial-gradient(circle at 20% 20%, rgba(255,77,186,.3), transparent 40%);
+}
+
+/* Nav */
+.nav{ display:flex; gap:12px; justify-content:center; flex-wrap:wrap; margin-bottom:18px; }
+.neon-btn{
+  padding:12px 18px; border-radius:10px; text-decoration:none; color:var(--ink);
+  border:2px solid rgba(23,18,31,.6);
+  box-shadow: 0 10px 0 rgba(23,18,31,.7), 0 8px 28px rgba(0,0,0,.4);
+  background: linear-gradient(135deg, #ffd166 0%, #ff4dba 50%, #6ff3ff 100%);
+  font-family: var(--font-mono);
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  transition: transform .12s ease, box-shadow .12s ease, filter .2s ease;
+}
+.neon-btn:hover{ transform: translateY(-3px); box-shadow: 0 13px 0 rgba(23,18,31,.7), 0 12px 32px rgba(0,0,0,.5); filter:saturate(1.15); }
 
 /* Layout */
 .container{ width:min(960px, 92%); margin: 0 auto; }
@@ -217,6 +308,7 @@ body::before{
   overflow-y: auto;            /* allow vertical scrolling */
   -ms-overflow-style: none;    /* IE/Edge */
   scrollbar-width: none;       /* Firefox */
+  padding:0 0 20px;
 }
 
 .content::-webkit-scrollbar {
@@ -238,22 +330,26 @@ body::before{
 
 .load-more-btn{
   cursor:pointer;
-  font-family:"Share Tech Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  font-size:13px;
+  font-family:var(--font-mono);
+  font-size:14px;
   text-transform:uppercase;
-  letter-spacing:.12em;
+  letter-spacing:.16em;
+  background: linear-gradient(135deg, rgba(255,209,102,.95), rgba(111,243,255,.9));
+  color:var(--ink);
+  border:2px solid rgba(23,18,31,.8);
+  box-shadow:0 10px 0 rgba(23,18,31,.7), 0 12px 32px rgba(0,0,0,.45);
 }
 
 .load-more-btn:disabled{
   cursor:not-allowed;
   opacity:.6;
-  box-shadow:0 0 10px var(--shadow), inset 0 0 8px rgba(255,0,204,.2);
+  box-shadow:0 6px 0 rgba(23,18,31,.6), inset 0 0 8px rgba(255,77,186,.2);
   transform:none;
 }
 
 .load-more-btn:disabled:hover{
-  border-color:rgba(0,229,255,.4);
-  box-shadow:0 0 10px var(--shadow), inset 0 0 8px rgba(255,0,204,.2);
+  border-color:rgba(23,18,31,.6);
+  box-shadow:0 6px 0 rgba(23,18,31,.6), inset 0 0 8px rgba(255,77,186,.2);
   transform:none;
 }
 
@@ -270,28 +366,30 @@ body::before{
 
 /* Cards (posts) */
 .card{
-  background: linear-gradient(180deg, rgba(10,15,31,.7), rgba(10,15,31,.5));
-  border:1px solid rgba(0,229,255,.18);
-  border-radius: var(--radius);
-  padding: 18px 18px 14px;
-  margin: 18px 0;
-  box-shadow: 0 0 32px rgba(0,229,255,.15), 0 0 64px rgba(255,0,204,.08);
+  background: linear-gradient(125deg, rgba(17,12,32,.9) 0%, rgba(17,12,32,.72) 50%, rgba(17,12,32,.92) 100%);
+  border:2px solid rgba(255,209,102,.4);
+  border-radius: 18px;
+  padding: 22px 20px 18px;
+  margin: 20px 0;
+  box-shadow: 0 16px 40px rgba(0,0,0,.45), 0 0 0 3px rgba(23,18,31,.7), 0 0 48px rgba(255,77,186,.16);
   position:relative;
   overflow:hidden;
 }
 .card::after{
-  content:""; position:absolute; inset:-2px;
-  background: conic-gradient(from 0deg, transparent 0 300deg, rgba(0,229,255,.35) 320deg, rgba(255,0,204,.35) 360deg);
-  filter: blur(16px); z-index:-1;
-  animation: spin 14s linear infinite;
-  opacity:.25;
+  content:""; position:absolute; inset:0;
+  background:
+    linear-gradient(135deg, rgba(255,209,102,.1), transparent 32%),
+    linear-gradient(315deg, rgba(111,243,255,.12), transparent 35%);
+  z-index:-1;
+  opacity:.6;
 }
-@keyframes spin { to { transform: rotate(1turn); } }
 
 .post-title{
   margin: 0 0 8px;
-  font-family:"Orbitron", system-ui, sans-serif;
-  letter-spacing:.04em;
+  font-family: var(--font-mono);
+  letter-spacing:.14em;
+  text-transform:uppercase;
+  color:var(--fg);
 }
 
 .post-title a{
@@ -307,6 +405,7 @@ body::before{
   margin: 0 0 16px;
   color: var(--dim);
   font-size: 13px;
+  letter-spacing:.08em;
 }
 
 .meta a{
@@ -335,15 +434,16 @@ body::before{
 
 .git-log{
   margin:0;
-  padding:16px;
-  background:rgba(4,6,13,.65);
-  border:1px solid rgba(0,229,255,.2);
+  padding:18px;
+  background:rgba(12,10,20,.82);
+  border:1px solid rgba(255,209,102,.28);
   border-radius:12px;
-  font-size:14px;
-  line-height:1.6;
+  font-size:15px;
+  line-height:1.55;
   white-space:pre-wrap;
   word-break:break-word;
-  box-shadow: inset 0 0 22px rgba(0,229,255,.08);
+  box-shadow: inset 0 0 22px rgba(255,77,186,.12);
+  font-family: var(--font-mono);
 }
 
 .commit-actions{
@@ -359,9 +459,9 @@ body::before{
   gap:6px;
   padding:6px 14px;
   border-radius:999px;
-  border:1px solid rgba(0,229,255,.35);
-  background: rgba(10,15,31,.55);
-  color:var(--fg);
+  border:1px solid rgba(255,209,102,.35);
+  background: rgba(15,12,24,.75);
+  color:var(--amber);
   text-decoration:none;
   font-size:12px;
   text-transform:uppercase;
@@ -370,7 +470,7 @@ body::before{
 }
 
 .chip:hover{
-  border-color:var(--cyan);
-  box-shadow:0 0 14px rgba(0,229,255,.24);
+  border-color:var(--amber);
+  box-shadow:0 0 14px rgba(255,209,102,.28);
   transform:translateY(-1px);
 }


### PR DESCRIPTION
## Summary
- refresh the landing page shell with retro 1980s computer advertisement copy and badge styling
- swap typography and background treatments for neon-print inspired palettes and grids
- restyle cards, buttons, and commit log elements to match the new theme while preserving functionality

## Testing
- not run (no Makefile present in repository)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289f93c8808327b676f53a38badf3a)