### PR TITLE
Use local Modern DOS font

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
   <title>BUDOSTACK</title>
 
   <!-- Fonts + Styles -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/c64-pro-mono" crossorigin="anonymous">
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
   <meta name="theme-color" content="#40318d">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" crossorigin="anonymous"></script>

--- a/style.css
+++ b/style.css
@@ -1,4 +1,12 @@
 /* ========== Variables & Base ========== */
+@font-face {
+  font-family: 'Modern DOS 8x8';
+  src: url('fonts/ModernDOS8x8.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
 :root {
   --screen-bg: #40318d;
   --screen-border: #6c5eb5;
@@ -17,7 +25,7 @@ body {
   background: radial-gradient(circle at 15% 15%, rgba(255,255,255,0.08), transparent 30%),
               radial-gradient(circle at 80% 70%, rgba(255,255,255,0.06), transparent 36%),
               var(--screen-bg);
-  font-family: 'C64 Pro Mono', 'Press Start 2P', 'IBM Plex Mono', monospace;
+  font-family: 'Modern DOS 8x8', monospace;
   line-height: 1.6;
   display: flex;
   flex-direction: column;
@@ -109,7 +117,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; }
 }
 
 .logo {
-  font-family: 'C64 Pro Mono', 'Press Start 2P', 'IBM Plex Mono', monospace;
+  font-family: 'Modern DOS 8x8', monospace;
   font-weight: 700;
   font-size: clamp(30px, 6vw, 52px);
   letter-spacing: .08em;
@@ -180,7 +188,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; }
 
 .load-more-btn {
   cursor: pointer;
-  font-family: 'C64 Pro Mono', 'Press Start 2P', 'IBM Plex Mono', monospace;
+  font-family: 'Modern DOS 8x8', monospace;
   font-size: 13px;
   text-transform: uppercase;
   letter-spacing: .12em;
@@ -276,7 +284,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; }
   white-space: pre-wrap;
   word-break: break-word;
   box-shadow: inset 0 0 22px rgba(36,17,95,0.5);
-  font-family: 'C64 Pro Mono', 'Press Start 2P', 'IBM Plex Mono', monospace;
+  font-family: 'Modern DOS 8x8', monospace;
   color: var(--screen-text);
 }
 


### PR DESCRIPTION
## Summary
- load the Modern DOS 8x8 font locally and use it as the primary typeface across the site
- remove external font dependencies so typography relies solely on the bundled font

## Testing
- make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a777b0888327b06d2b4f518cd990)