### PR TITLE
Allow header to scroll with page

### DIFF
--- a/style.css
+++ b/style.css
@@ -161,7 +161,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; }
   flex-shrink: 0;
   letter-spacing: 0.08em;
   border-top: 2px solid var(--screen-border);
-  background: rgba(0,0,0,0.2);
+  background: var(--screen-bg);
   position: sticky;
   bottom: 0;
   z-index: 5;

--- a/style.css
+++ b/style.css
@@ -49,7 +49,7 @@ body {
   flex-direction: column;
   min-height: 100vh;
   overflow-x: hidden;
-  overflow-y: hidden;
+  overflow-y: auto;
   letter-spacing: 0.04em;
 }
 
@@ -188,7 +188,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; }
 
 /* Layout */
 .container { width:min(980px, 92%); margin: 0 auto; }
-.content { flex:1 1 auto; overflow-y: auto; padding-bottom: 30px; }
+.content { flex:1 1 auto; padding-bottom: 30px; }
 
 .feed-list {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -162,6 +162,9 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; }
   letter-spacing: 0.08em;
   border-top: 2px solid var(--screen-border);
   background: rgba(0,0,0,0.2);
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
 }
 
 /* Nav */


### PR DESCRIPTION
## Summary
- enable page-level scrolling so the site header moves with the rest of the content
- remove nested scroll behavior on the content area while keeping the footer layout intact

## Testing
- make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c324539c8327b25f9e7b17e47769)