### PR TITLE
Bust cache when loading newsroom markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,13 @@
       if (!newsContentEl) return;
       newsContentEl.innerHTML = '<p>Loading latest news...</p>';
       try {
-        const response = await fetch(NEWS_SOURCE_URL, { headers: { 'Accept': 'text/plain' } });
+        const cacheBuster = Date.now();
+        const newsUrl = `${NEWS_SOURCE_URL}?cache=${cacheBuster}`;
+
+        const response = await fetch(newsUrl, {
+          headers: { 'Accept': 'text/plain' },
+          cache: 'no-store'
+        });
         if (!response.ok) throw new Error(`Failed to load news: ${response.status}`);
 
         const markdown = await response.text();


### PR DESCRIPTION
## Summary
- add a cache-busting query parameter when fetching newsroom markdown
- disable caching in the news fetch request to ensure the latest updates load

## Testing
- make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c8e8004c83279d146593a803f343)