### PR TITLE
Preserve empty lines in news markdown rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,13 @@
 
     const newsContentEl = document.getElementById('news-content');
 
+    function preserveEmptyLines(markdown = '') {
+      return markdown
+        .split(/\r?\n/)
+        .map(line => (line.trim() === '' ? '&nbsp;' : line))
+        .join('\n');
+    }
+
     function buildNewsSections(markdown) {
       const lines = markdown.split(/\r?\n/);
       const sections = [];
@@ -100,7 +107,7 @@
       return sections
         .map(({ title, body }) => ({
           title,
-          markdown: body.join('\n').trim()
+          markdown: preserveEmptyLines(body.join('\n').trim())
         }))
         .filter(section => section.title || section.markdown);
     }
@@ -144,7 +151,7 @@
         const sections = buildNewsSections(markdown);
 
         if (!sections.length) {
-          const rendered = DOMPurify.sanitize(marked.parse(markdown));
+          const rendered = DOMPurify.sanitize(marked.parse(preserveEmptyLines(markdown)));
           newsContentEl.innerHTML = rendered;
           return;
         }

--- a/index.html
+++ b/index.html
@@ -81,9 +81,10 @@
     const newsContentEl = document.getElementById('news-content');
 
     function preserveEmptyLines(markdown = '') {
+      const EMPTY_PLACEHOLDER = '<div class="md-empty-line" aria-hidden="true"></div>';
       return markdown
         .split(/\r?\n/)
-        .map(line => (line.trim() === '' ? '&nbsp;' : line))
+        .map(line => (line.trim() === '' ? EMPTY_PLACEHOLDER : line))
         .join('\n');
     }
 

--- a/style.css
+++ b/style.css
@@ -377,6 +377,10 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; }
 
 .news-body p { margin: 4px 0; }
 
+.news-body .md-empty-line {
+  min-height: 1.25em;
+}
+
 .news-content h1,
 .news-content h2,
 .news-content h3,


### PR DESCRIPTION
## Summary
- add helper to preserve empty lines in news markdown by substituting non-breaking spaces
- apply empty-line preservation for sectioned and fallback news rendering to keep spacing consistent

## Testing
- make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d211dbd88327b8a22ac9ee2326a6)