### PR TITLE
Handle br lines in news markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
     function normalizeNewsMarkdown(markdown) {
       return markdown
         .split(/\r?\n/)
-        .map(line => line.match(/^<br\s*\/?>(\s*)?$/i) ? '' : line)
+        .map(line => line.match(/^\s*<br\s*\/?>(\s*)?$/i) ? '' : line)
         .join('\n');
     }
 

--- a/index.html
+++ b/index.html
@@ -80,6 +80,13 @@
 
     const newsContentEl = document.getElementById('news-content');
 
+    function normalizeNewsMarkdown(markdown) {
+      return markdown
+        .split(/\r?\n/)
+        .map(line => line.match(/^<br\s*\/?>(\s*)?$/i) ? '' : line)
+        .join('\n');
+    }
+
     function buildNewsSections(markdown) {
       const lines = markdown.split(/\r?\n/);
       const sections = [];
@@ -140,7 +147,7 @@
         const response = await fetch(NEWS_SOURCE_URL, { headers: { 'Accept': 'text/plain' } });
         if (!response.ok) throw new Error(`Failed to load news: ${response.status}`);
 
-        const markdown = await response.text();
+        const markdown = normalizeNewsMarkdown(await response.text());
         const sections = buildNewsSections(markdown);
 
         if (!sections.length) {


### PR DESCRIPTION
## Summary
- normalize newsroom markdown so standalone <br> tags count as empty rows
- apply normalization before parsing sections to keep news layout consistent

## Testing
- make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d4b4142083279dcee650e86c882b)